### PR TITLE
Handle when influences are not defined

### DIFF
--- a/scripts/masks.mjs
+++ b/scripts/masks.mjs
@@ -146,7 +146,7 @@ function onInfluenceAction(actor, html) {
         const clickedElement = $(event.currentTarget);
         const action = clickedElement.data().influenceAction;
         let influenceID = clickedElement.parents("[data-influence-id]").data().influenceId;
-        let influences = actor.getFlag("masks-newgeneration-unofficial", "influences");
+        let influences = actor.getFlag("masks-newgeneration-unofficial", "influences") ?? [];
         let influence = influences.find(i => i.id === influenceID);
 
         if (influence.locked && /lock|roll/.exec(action) === null) {


### PR DESCRIPTION
This should fix the following issue in the console when creating a new influence for an actor:
```
masks.mjs:125  Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'push')
    at HTMLButtonElement.<anonymous> (masks.mjs:125:20)
    at HTMLButtonElement.dispatch (jquery.min.js:2:43184)
    at y.handle (jquery.min.js:2:41168)
```